### PR TITLE
Couchbase handle JArray support.

### DIFF
--- a/src/CacheManager.Couchbase/BucketCacheHandle.cs
+++ b/src/CacheManager.Couchbase/BucketCacheHandle.cs
@@ -146,14 +146,9 @@ namespace CacheManager.Couchbase
             if (result.Success)
             {
                 var cacheItem = result.Value;
-                if (cacheItem.Value.GetType() == typeof(JValue))
+                if (cacheItem.Value is JToken)
                 {
-                    var value = cacheItem.Value as JValue;
-                    cacheItem = cacheItem.WithValue((TCacheValue)value.ToObject(cacheItem.ValueType));
-                }
-                else if (cacheItem.Value.GetType() == typeof(JObject))
-                {
-                    var value = cacheItem.Value as JObject;
+                    var value = cacheItem.Value as JToken;
                     cacheItem = cacheItem.WithValue((TCacheValue)value.ToObject(cacheItem.ValueType));
                 }
 


### PR DESCRIPTION
I had an issue where I couldn't store arrays/collections straight into couchbase using the BucketCacheHandle resulting in an InvalidCastException when BaseCache uses GetCasted to return the expected type.

I've currently had to work around this by wrapping up all my cached items in another object so that the deserialisation happens as part of a child property deserialisation automatically when ToObject is called on a JObject value type.

I noticed that there are a couple of checks to see what type the cache item value was and determined that JValue and JObject both inherit from JToken, as does JArray. Since JToken has the ToObject method it seemed prudent to only check if the cache item value is an instance of JToken.

This should allow all JToken derived values to be used.