### PR TITLE
Support GetOrAdd and TryGetOrAdd for CacheItem

### DIFF
--- a/src/CacheManager.Core/BaseCacheManager.GetOrAdd.cs
+++ b/src/CacheManager.Core/BaseCacheManager.GetOrAdd.cs
@@ -58,23 +58,22 @@ namespace CacheManager.Core
             NotNullOrWhiteSpace(key, nameof(key));
             NotNull(valueFactory, nameof(valueFactory));
 
-            CacheItem<TCacheValue> item = default(CacheItem<TCacheValue>);
-            value = default(TCacheValue);
-            Func<string, string, CacheItem<TCacheValue>> cacheItemCreator = (k, r) =>
-            {
-                var outValue = valueFactory(k);
-                if (outValue == null)
+            if (TryGetOrAddInternal(
+                key,
+                null,
+                (k, r) =>
                 {
-                    return null;
-                }
-                return new CacheItem<TCacheValue>(k, outValue);
-            };
-            var returnValue = TryGetOrAddInternal(key, null, cacheItemCreator, out item);
-            if (returnValue)
+                    var newValue = valueFactory(k);
+                    return newValue == null ? null : new CacheItem<TCacheValue>(k, newValue);
+                },
+                out CacheItem<TCacheValue> item))
             {
                 value = item.Value;
+                return true;
             }
-            return returnValue;
+
+            value = default(TCacheValue);
+            return false;
         }
 
         /// <inheritdoc />
@@ -84,23 +83,22 @@ namespace CacheManager.Core
             NotNullOrWhiteSpace(region, nameof(region));
             NotNull(valueFactory, nameof(valueFactory));
 
-            CacheItem<TCacheValue> item = default(CacheItem<TCacheValue>);
-            value = default(TCacheValue);
-            Func<string, string, CacheItem<TCacheValue>> cacheItemCreator = (k, r) =>
-            {
-                var outValue = valueFactory(k, r);
-                if (outValue == null)
+            if (TryGetOrAddInternal(
+                key,
+                region,
+                (k, r) =>
                 {
-                    return null;
-                }
-                return new CacheItem<TCacheValue>(k, r, outValue);
-            };
-            var returnValue = TryGetOrAddInternal(key, region, cacheItemCreator, out item);
-            if (returnValue)
+                    var newValue = valueFactory(k, r);
+                    return newValue == null ? null : new CacheItem<TCacheValue>(k, r, newValue);
+                },
+                out CacheItem<TCacheValue> item))
             {
                 value = item.Value;
+                return true;
             }
-            return returnValue;
+
+            value = default(TCacheValue);
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/CacheManager.Core/BaseCacheManager.GetOrAdd.cs
+++ b/src/CacheManager.Core/BaseCacheManager.GetOrAdd.cs
@@ -169,7 +169,7 @@ namespace CacheManager.Core
                 // Throw explicit to me more consistent. Otherwise it would throw later eventually...
                 if (item == null)
                 {
-                    throw new InvalidOperationException("The value which should be added must not be null.");
+                    throw new InvalidOperationException("The CacheItem which should be added must not be null.");
                 }
 
                 if (AddInternal(item))

--- a/src/CacheManager.Core/ICacheManager.cs
+++ b/src/CacheManager.Core/ICacheManager.cs
@@ -338,6 +338,31 @@ namespace CacheManager.Core
         TCacheValue GetOrAdd(string key, string region, Func<string, string, TCacheValue> valueFactory);
 
         /// <summary>
+        /// Returns an existing item or adds the item to the cache if it does not exist.
+        /// The <paramref name="valueFactory"/> will be evaluated only if the item does not exist.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="valueFactory">The method which creates the value which should be added.</param>
+        /// <returns>Either the added or the existing value.</returns>
+        /// <exception cref="ArgumentException">
+        /// If either <paramref name="key"/> or <paramref name="valueFactory"/> is null.
+        /// </exception>
+        CacheItem<TCacheValue> GetOrAdd(string key, Func<string, CacheItem<TCacheValue>> valueFactory);
+
+        /// <summary>
+        /// Returns an existing item or adds the item to the cache if it does not exist.
+        /// The <paramref name="valueFactory"/> will be evaluated only if the item does not exist.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="region">The cache region.</param>
+        /// <param name="valueFactory">The method which creates the value which should be added.</param>
+        /// <returns>Either the added or the existing value.</returns>
+        /// <exception cref="ArgumentException">
+        /// If either <paramref name="key"/> or <paramref name="valueFactory"/> is null.
+        /// </exception>
+        CacheItem<TCacheValue> GetOrAdd(string key, string region, Func<string, string, CacheItem<TCacheValue>> valueFactory);
+
+        /// <summary>
         /// Tries to either retrieve an existing item or add the item to the cache if it does not exist.
         /// The <paramref name="valueFactory"/> will be evaluated only if the item does not exist.
         /// </summary>
@@ -363,6 +388,31 @@ namespace CacheManager.Core
         /// If either <paramref name="key"/> or <paramref name="valueFactory"/> is null.
         /// </exception>
         bool TryGetOrAdd(string key, string region, Func<string, string, TCacheValue> valueFactory, out TCacheValue value);
+
+        /// <summary>
+        /// Tries to either retrieve an existing item or add the item to the cache if it does not exist.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="valueFactory">The method which creates the value which should be added.</param>
+        /// <param name="item">The cache item.</param>
+        /// <returns><c>True</c> if the operation succeeds, <c>False</c> in case there are too many retries or the <paramref name="valueFactory"/> returns null.</returns>
+        /// <exception cref="ArgumentException">
+        /// If either <paramref name="key"/> or <paramref name="valueFactory"/> is null.
+        /// </exception>
+        bool TryGetOrAdd(string key, Func<string, CacheItem<TCacheValue>> valueFactory, out CacheItem<TCacheValue> item);
+
+        /// <summary>
+        /// Tries to either retrieve an existing item or add the item to the cache if it does not exist.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="region">The cache region.</param>
+        /// <param name="valueFactory">The method which creates the value which should be added.</param>
+        /// <param name="item">The cache item.</param>
+        /// <returns><c>True</c> if the operation succeeds, <c>False</c> in case there are too many retries or the <paramref name="valueFactory"/> returns null.</returns>
+        /// <exception cref="ArgumentException">
+        /// If either <paramref name="key"/> or <paramref name="valueFactory"/> is null.
+        /// </exception>
+        bool TryGetOrAdd(string key, string region, Func<string, string, CacheItem<TCacheValue>> valueFactory, out CacheItem<TCacheValue> item);
 
         /// <summary>
         /// Updates an existing key in the cache.


### PR DESCRIPTION
Fixes #152.

I have modified tests to cover the new code, but I have not run them, because I don't have redis setup on Windows at the moment.

I duplicated the helper functions used by the other code for the CacheItem version, as I couldn't figure out a way of rewriting the helpers that I was happy with. The obvious way would be to make sure they took a CacheItem and then make the other versions create one on the fly, but that seems a bit wasteful memory-wise especially since it often ends up being unused. Anyway, I'm leaving it up to you. If you want me to rewrite things some other way, by all means ask and I will do so.