### PR TITLE
Fixing concurrency issue in Memory Cache

### DIFF
--- a/src/CacheManager.Microsoft.Extensions.Caching.Memory/MemoryCacheExtensions.cs
+++ b/src/CacheManager.Microsoft.Extensions.Caching.Memory/MemoryCacheExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
@@ -24,21 +25,19 @@ namespace CacheManager.MicrosoftCachingMemory
 
         internal static void RegisterChild(this MemoryCache cache, object parentKey, object childKey)
         {
-            object temp;
-            if (cache.TryGetValue(parentKey, out temp))
+            if (cache.TryGetValue(parentKey, out var keys))
             {
-                var set = (HashSet<object>)temp;
-                set.Add(childKey);
+                var keySet = (ConcurrentDictionary<object, bool>)keys;
+                keySet.TryAdd(childKey, true);
             }
         }
 
         internal static void RemoveChilds(this MemoryCache cache, object region)
         {
-            object keys;
-            if (cache.TryGetValue(region, out keys))
+            if (cache.TryGetValue(region, out var keys))
             {
-                var keySet = (HashSet<object>)keys;
-                foreach (var key in keySet)
+                var keySet = (ConcurrentDictionary<object, bool>)keys;
+                foreach (var key in keySet.Keys)
                 {
                     cache.Remove(key);
                 }

--- a/src/CacheManager.Microsoft.Extensions.Caching.Memory/MemoryCacheHandle`1.cs
+++ b/src/CacheManager.Microsoft.Extensions.Caching.Memory/MemoryCacheHandle`1.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using CacheManager.Core;
 using CacheManager.Core.Internal;
 using CacheManager.Core.Logging;
@@ -227,7 +227,7 @@ namespace CacheManager.MicrosoftCachingMemory
                 SlidingExpiration = TimeSpan.MaxValue,
             };
 
-            _cache.Set(region, new HashSet<object>(), options);
+            _cache.Set(region, new ConcurrentDictionary<object, bool>(), options);
         }
 
         private void ItemRemoved(object key, object value, EvictionReason reason, object state)


### PR DESCRIPTION
I'm seeing some System.IndexOutOfRangeException exceptions in our
application caused by corruption of the child regions HashSet. This
appears to be caused by concurrent writes to the data structure. I'm
replacing the HashSet with a ConcurrentDictionary. This isn't ideal as
each key also has to store a bogus value, but there is no builtin
concurrent HashSet and this seemed to be a better solution than explicit
locking.