### PR TITLE
Wrap the exception so that the StackTrace is kept

### DIFF
--- a/src/CacheManager.Core/BaseCacheManager.cs
+++ b/src/CacheManager.Core/BaseCacheManager.cs
@@ -127,7 +127,9 @@ namespace CacheManager.Core
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error occurred while creating the cache manager.");
-                throw ex.InnerException ?? ex;
+                throw new ApplicationException(
+                    "Error occurred while creating the cache manager.",
+                    ex.InnerException ?? ex);
             }
         }
 


### PR DESCRIPTION
Fixes #303 

Breaking change in that the exception type thrown to the caller will not be the same. May not need a major version bump though since it's only a breaking change on an exception path.

Option 1. Option 2 will back-link to this review