### PR TITLE
Add Rethrow() method and use in BaseCacheManager

### DIFF
--- a/src/CacheManager.Core/BaseCacheManager.cs
+++ b/src/CacheManager.Core/BaseCacheManager.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using CacheManager.Core.Internal;
 using CacheManager.Core.Logging;
+using CacheManager.Core.Utility;
 using static CacheManager.Core.Utility.Guard;
 
 namespace CacheManager.Core
@@ -127,7 +128,7 @@ namespace CacheManager.Core
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Error occurred while creating the cache manager.");
-                throw ex.InnerException ?? ex;
+                Throw.Rethrow(ex.InnerException ?? ex);
             }
         }
 

--- a/src/CacheManager.Core/Utility/Throw.cs
+++ b/src/CacheManager.Core/Utility/Throw.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.ExceptionServices;
+
+namespace CacheManager.Core.Utility
+{
+    /// <summary>
+    /// <see cref="Exception"/> related helper.
+    /// </summary>
+    internal static class Throw
+    {
+        /// <summary>
+        /// Rethrows the supplied exception without losing its stack trace.
+        /// Prefer <code>throw;</code> where possible, this method is useful for rethrowing
+        /// <see cref="Exception.InnerException" />
+        /// which cannot be done with the <code>throw;</code> semantics.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        public static void Rethrow(
+            this Exception exception)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #303

A little less "standard" than a wrapping exception, but satisfies the requirements without functional change beyond the stack trace. Does lose the stack trace of BaseCacheManager:L130, instead doing the Logger.LogError and then claiming to have broken control straight from wherever the exception was thrown to the outer exception handler.

Option 2 - alternative to #306 
