### PR TITLE
Fix infinite loop in CheckExtends

### DIFF
--- a/src/CacheManager.Core/Internal/CacheReflectionHelper.cs
+++ b/src/CacheManager.Core/Internal/CacheReflectionHelper.cs
@@ -318,7 +318,7 @@ namespace CacheManager.Core.Internal
                     return;
                 }
 
-                baseType = type.BaseType;
+                baseType = baseType.BaseType;
             }
 
             throw new InvalidOperationException(


### PR DESCRIPTION
Pretty self-explanatory - intention is to traverse base type hierarchy, not to check the same one over and over again.
As a side-note, this whole function should probably be replaced with
`typeof(TValid).IsAssignableFrom(type)`